### PR TITLE
Improved the Twig extension to avoid having to use the raw filter

### DIFF
--- a/Extension/HyphenatorTwigExtension.php
+++ b/Extension/HyphenatorTwigExtension.php
@@ -2,8 +2,8 @@
 
 namespace Liip\HyphenatorBundle\Extension;
 
-class HyphenatorTwigExtension extends \Twig_Extension {
-
+class HyphenatorTwigExtension extends \Twig_Extension
+{
     private $hyphenator;
 
     public function setHyphenator($hyphenator)
@@ -14,7 +14,7 @@ class HyphenatorTwigExtension extends \Twig_Extension {
     public function getFilters()
     {
         return array(
-            'hyphenate'  => new \Twig_Filter_Method($this, 'hyphenate'),
+            'hyphenate'  => new \Twig_Filter_Method($this, 'hyphenate', array('pre_escape' => 'html', 'is_safe' => array('html'))),
         );
     }
 
@@ -25,7 +25,6 @@ class HyphenatorTwigExtension extends \Twig_Extension {
 
     public function getName()
     {
-        return 'hyphenator_twig_extension';
+        return 'liip_hyphenator';
     }
-
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About ##
 
-Adds support for _hyphenating_ long words using the [Org_Heigl_Hyphenator](https://github.com/heiglandreas/Org_Heigl_Hyphenator) library. 
+Adds support for _hyphenating_ long words using the [Org_Heigl_Hyphenator](https://github.com/heiglandreas/Org_Heigl_Hyphenator) library.
 
 This bundle will add a Twig Extension for templates and a Hyphenator service.
 
@@ -68,9 +68,7 @@ Then on your `config.yml` file you need to add a line like:
 
 This library adds a filter for twig templates that can be used like:
 
-    {{ "Somelongwordtohyphenate"|hyphenate|raw }}
-
-Since it's using soft-hyphens you need to add the `raw` filter in order that the `&shy;` characters are sent to the templates.
+    {{ "Somelongwordtohyphenate"|hyphenate }}
 
 ## License ##
 


### PR DESCRIPTION
Btw, using the raw filter the way you described it was a XSS hole. You should have used

``` jinja
{{ somethingLong|e|hyphenate }}
```

to escape the value before passing it to the filter as the filter itself did not handle escaping.

the new way to do it solves this issue as well.
