### PR TITLE
Updating WhitespaceTokenizer service

### DIFF
--- a/Resources/config/hyphenator.xml
+++ b/Resources/config/hyphenator.xml
@@ -45,7 +45,7 @@
             </call>
         </service>
 
-        <service id="liip_hyphenator.tokenizer.whitespace" class="Org\Heigl\Hyphenator\Tokenizer\WhiteSpaceTokenizer" />
+        <service id="liip_hyphenator.tokenizer.whitespace" class="Org\Heigl\Hyphenator\Tokenizer\WhitespaceTokenizer" />
         <service id="liip_hyphenator.tokenizer.punctuation" class="Org\Heigl\Hyphenator\Tokenizer\PunctuationTokenizer" />
 
         <service id="liip_hyphenator.filter.simple" class="Org\Heigl\Hyphenator\Filter\SimpleFilter" />


### PR DESCRIPTION
The class for service "liip_hyphenator.tokenizer.whitespace" is incorrect. The correct class is "WhitespaceTokenizer" not "WhiteSpaceTokenizer".
